### PR TITLE
Start local WebSocket provider on Binder with jupyter server proxy

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -4,4 +4,5 @@ channels:
 dependencies:
 - jupyterlab=3
 - jupyterlab-classic=0.1
+- jupyter-server-proxy
 - nodejs

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -4,3 +4,4 @@ channels:
 dependencies:
 - jupyterlab=3
 - jupyterlab-classic=0.1
+- nodejs

--- a/binder/jupyter_notebook_config.py
+++ b/binder/jupyter_notebook_config.py
@@ -1,0 +1,11 @@
+c.ServerProxy.servers = {
+    "y-websocket": {
+        "command": [
+            "HOST=localhost",
+            "PORT={port}",
+            "npx",
+            "y-websocket-server"
+        ],
+        "timeout": 120
+    }
+}

--- a/binder/jupyter_notebook_config.py
+++ b/binder/jupyter_notebook_config.py
@@ -1,9 +1,11 @@
+import sys
+
 c.ServerProxy.servers = {
     "y-websocket": {
         "command": [
-            "HOST=localhost",
+            "HOST=0.0.0.0",
             "PORT=1234",
-            "npx",
+            f"{sys.prefix}/bin/npx",
             "-y",
             "y-websocket"
         ],

--- a/binder/jupyter_notebook_config.py
+++ b/binder/jupyter_notebook_config.py
@@ -4,7 +4,8 @@ c.ServerProxy.servers = {
             "HOST=localhost",
             "PORT={port}",
             "npx",
-            "y-websocket-server"
+            "-y",
+            "y-websocket"
         ],
         "timeout": 120
     }

--- a/binder/jupyter_notebook_config.py
+++ b/binder/jupyter_notebook_config.py
@@ -2,7 +2,7 @@ c.ServerProxy.servers = {
     "y-websocket": {
         "command": [
             "HOST=localhost",
-            "PORT={port}",
+            "PORT=1234",
             "npx",
             "-y",
             "y-websocket"

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,1 +1,4 @@
 pip install jupyterlab-link-share .
+
+mkdir -p $HOME/.jupyter/
+cp binder/jupyter_notebook_config.py ${HOME}/.jupyter/

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ const editors: JupyterFrontEndPlugin<void> = {
       tracker.widgetAdded.connect((sender, widget) => {
         const ydoc = new Y.Doc();
         const provider = new WebsocketProvider(
-          'wss://demos.yjs.dev',
+          'ws://localhost:1234',
           `${WEBSOCKET_PROVIDER_PREFIX}-${widget.context.path}`,
           ydoc
         );


### PR DESCRIPTION
Fixes #3 

Testing on https://mybinder.org/v2/gh/jtpio/jupyterlab-yjs-example/ws-server-proxy?urlpath=/lab