### PR TITLE
Install Jupyterlab link share from conda

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -4,3 +4,4 @@ channels:
 dependencies:
 - jupyterlab=3
 - jupyterlab-classic=0.1
+- jupyterlab-link-share=0.1

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,1 +1,1 @@
-pip install jupyterlab-link-share .
+pip install .


### PR DESCRIPTION
Since it's now available: https://anaconda.org/conda-forge/jupyterlab-link-share